### PR TITLE
Update flatbuffers-java to the latest version and regenerate java code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Run the following commands:
 ```
 git submodule init
 git submodule update --recursive
+
+# make sure that the flatc version is the same
+# as the flatbuffers-java version in build.gradle
 flatc --java -b -o src/main/java/ extra/schema/fugue.fbs
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 dependencies {
     extraLibs 'com.google.guava:guava:30.1-jre'
     extraLibs 'commons-codec:commons-codec:1.15'
-    extraLibs 'com.google.flatbuffers:flatbuffers-java:2.0.2'
+    extraLibs 'com.google.flatbuffers:flatbuffers-java:23.3.3'
     configurations.implementation.extendsFrom(configurations.extraLibs)
 }
 //----------------------START "DO NOT MODIFY" SECTION------------------------------

--- a/src/main/java/fugue/schema/Architecture.java
+++ b/src/main/java/fugue/schema/Architecture.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class Architecture extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static Architecture getRootAsArchitecture(ByteBuffer _bb) { return getRootAsArchitecture(_bb, new Architecture()); }
   public static Architecture getRootAsArchitecture(ByteBuffer _bb, Architecture obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
@@ -48,7 +60,7 @@ public final class Architecture extends Table {
   public static void startArchitecture(FlatBufferBuilder builder) { builder.startTable(5); }
   public static void addProcessor(FlatBufferBuilder builder, int processorOffset) { builder.addOffset(0, processorOffset, 0); }
   public static void addEndian(FlatBufferBuilder builder, boolean endian) { builder.addBoolean(1, endian, false); }
-  public static void addBits(FlatBufferBuilder builder, long bits) { builder.addInt(2, (int)bits, (int)0L); }
+  public static void addBits(FlatBufferBuilder builder, long bits) { builder.addInt(2, (int) bits, (int) 0L); }
   public static void addVariant(FlatBufferBuilder builder, int variantOffset) { builder.addOffset(3, variantOffset, 0); }
   public static void addAuxiliary(FlatBufferBuilder builder, int auxiliaryOffset) { builder.addOffset(4, auxiliaryOffset, 0); }
   public static int createAuxiliaryVector(FlatBufferBuilder builder, byte[] data) { return builder.createByteVector(data); }

--- a/src/main/java/fugue/schema/BasicBlock.java
+++ b/src/main/java/fugue/schema/BasicBlock.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class BasicBlock extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static BasicBlock getRootAsBasicBlock(ByteBuffer _bb) { return getRootAsBasicBlock(_bb, new BasicBlock()); }
   public static BasicBlock getRootAsBasicBlock(ByteBuffer _bb, BasicBlock obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
@@ -54,8 +66,8 @@ public final class BasicBlock extends Table {
 
   public static void startBasicBlock(FlatBufferBuilder builder) { builder.startTable(6); }
   public static void addAddress(FlatBufferBuilder builder, long address) { builder.addLong(0, address, 0L); }
-  public static void addSize(FlatBufferBuilder builder, long size) { builder.addInt(1, (int)size, (int)0L); }
-  public static void addArchitecture(FlatBufferBuilder builder, long architecture) { builder.addInt(2, (int)architecture, (int)0L); }
+  public static void addSize(FlatBufferBuilder builder, long size) { builder.addInt(1, (int) size, (int) 0L); }
+  public static void addArchitecture(FlatBufferBuilder builder, long architecture) { builder.addInt(2, (int) architecture, (int) 0L); }
   public static void addPredecessors(FlatBufferBuilder builder, int predecessorsOffset) { builder.addOffset(3, predecessorsOffset, 0); }
   public static int createPredecessorsVector(FlatBufferBuilder builder, int[] data) { builder.startVector(4, data.length, 4); for (int i = data.length - 1; i >= 0; i--) builder.addOffset(data[i]); return builder.endVector(); }
   public static void startPredecessorsVector(FlatBufferBuilder builder, int numElems) { builder.startVector(4, numElems, 4); }

--- a/src/main/java/fugue/schema/Function.java
+++ b/src/main/java/fugue/schema/Function.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class Function extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static Function getRootAsFunction(ByteBuffer _bb) { return getRootAsFunction(_bb, new Function()); }
   public static Function getRootAsFunction(ByteBuffer _bb, Function obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }

--- a/src/main/java/fugue/schema/InterRef.java
+++ b/src/main/java/fugue/schema/InterRef.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class InterRef extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static InterRef getRootAsInterRef(ByteBuffer _bb) { return getRootAsInterRef(_bb, new InterRef()); }
   public static InterRef getRootAsInterRef(ByteBuffer _bb, InterRef obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
@@ -43,8 +55,8 @@ public final class InterRef extends Table {
 
   public static void startInterRef(FlatBufferBuilder builder) { builder.startTable(5); }
   public static void addAddress(FlatBufferBuilder builder, long address) { builder.addLong(0, address, 0L); }
-  public static void addSource(FlatBufferBuilder builder, long source) { builder.addInt(1, (int)source, (int)4294967295L); }
-  public static void addTarget(FlatBufferBuilder builder, long target) { builder.addInt(2, (int)target, (int)0L); }
+  public static void addSource(FlatBufferBuilder builder, long source) { builder.addInt(1, (int) source, (int) 4294967295L); }
+  public static void addTarget(FlatBufferBuilder builder, long target) { builder.addInt(2, (int) target, (int) 0L); }
   public static void addCall(FlatBufferBuilder builder, boolean call) { builder.addBoolean(3, call, false); }
   public static void addAuxiliary(FlatBufferBuilder builder, int auxiliaryOffset) { builder.addOffset(4, auxiliaryOffset, 0); }
   public static int createAuxiliaryVector(FlatBufferBuilder builder, byte[] data) { return builder.createByteVector(data); }

--- a/src/main/java/fugue/schema/IntraRef.java
+++ b/src/main/java/fugue/schema/IntraRef.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class IntraRef extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static IntraRef getRootAsIntraRef(ByteBuffer _bb) { return getRootAsIntraRef(_bb, new IntraRef()); }
   public static IntraRef getRootAsIntraRef(ByteBuffer _bb, IntraRef obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
@@ -41,7 +53,7 @@ public final class IntraRef extends Table {
   public static void startIntraRef(FlatBufferBuilder builder) { builder.startTable(4); }
   public static void addSource(FlatBufferBuilder builder, long source) { builder.addLong(0, source, 0L); }
   public static void addTarget(FlatBufferBuilder builder, long target) { builder.addLong(1, target, 0L); }
-  public static void addFunction(FlatBufferBuilder builder, long function) { builder.addInt(2, (int)function, (int)0L); }
+  public static void addFunction(FlatBufferBuilder builder, long function) { builder.addInt(2, (int) function, (int) 0L); }
   public static void addAuxiliary(FlatBufferBuilder builder, int auxiliaryOffset) { builder.addOffset(3, auxiliaryOffset, 0); }
   public static int createAuxiliaryVector(FlatBufferBuilder builder, byte[] data) { return builder.createByteVector(data); }
   public static int createAuxiliaryVector(FlatBufferBuilder builder, ByteBuffer data) { return builder.createByteVector(data); }

--- a/src/main/java/fugue/schema/Metadata.java
+++ b/src/main/java/fugue/schema/Metadata.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class Metadata extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static Metadata getRootAsMetadata(ByteBuffer _bb) { return getRootAsMetadata(_bb, new Metadata()); }
   public static Metadata getRootAsMetadata(ByteBuffer _bb, Metadata obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
@@ -45,21 +57,21 @@ public final class Metadata extends Table {
   public ByteBuffer auxiliaryInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 16, 1); }
 
   public static int createMetadata(FlatBufferBuilder builder,
-      int input_formatOffset,
-      int input_pathOffset,
-      int input_md5Offset,
-      int input_sha256Offset,
-      long input_size,
+      int inputFormatOffset,
+      int inputPathOffset,
+      int inputMd5Offset,
+      int inputSha256Offset,
+      long inputSize,
       int exporterOffset,
       int auxiliaryOffset) {
     builder.startTable(7);
     Metadata.addAuxiliary(builder, auxiliaryOffset);
     Metadata.addExporter(builder, exporterOffset);
-    Metadata.addInputSize(builder, input_size);
-    Metadata.addInputSha256(builder, input_sha256Offset);
-    Metadata.addInputMd5(builder, input_md5Offset);
-    Metadata.addInputPath(builder, input_pathOffset);
-    Metadata.addInputFormat(builder, input_formatOffset);
+    Metadata.addInputSize(builder, inputSize);
+    Metadata.addInputSha256(builder, inputSha256Offset);
+    Metadata.addInputMd5(builder, inputMd5Offset);
+    Metadata.addInputPath(builder, inputPathOffset);
+    Metadata.addInputFormat(builder, inputFormatOffset);
     return Metadata.endMetadata(builder);
   }
 
@@ -74,7 +86,7 @@ public final class Metadata extends Table {
   public static int createInputSha256Vector(FlatBufferBuilder builder, byte[] data) { return builder.createByteVector(data); }
   public static int createInputSha256Vector(FlatBufferBuilder builder, ByteBuffer data) { return builder.createByteVector(data); }
   public static void startInputSha256Vector(FlatBufferBuilder builder, int numElems) { builder.startVector(1, numElems, 1); }
-  public static void addInputSize(FlatBufferBuilder builder, long inputSize) { builder.addInt(4, (int)inputSize, (int)0L); }
+  public static void addInputSize(FlatBufferBuilder builder, long inputSize) { builder.addInt(4, (int) inputSize, (int) 0L); }
   public static void addExporter(FlatBufferBuilder builder, int exporterOffset) { builder.addOffset(5, exporterOffset, 0); }
   public static void addAuxiliary(FlatBufferBuilder builder, int auxiliaryOffset) { builder.addOffset(6, auxiliaryOffset, 0); }
   public static int createAuxiliaryVector(FlatBufferBuilder builder, byte[] data) { return builder.createByteVector(data); }

--- a/src/main/java/fugue/schema/Project.java
+++ b/src/main/java/fugue/schema/Project.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class Project extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static Project getRootAsProject(ByteBuffer _bb) { return getRootAsProject(_bb, new Project()); }
   public static Project getRootAsProject(ByteBuffer _bb, Project obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public static boolean ProjectBufferHasIdentifier(ByteBuffer _bb) { return __has_identifier(_bb, "FuDb"); }

--- a/src/main/java/fugue/schema/Segment.java
+++ b/src/main/java/fugue/schema/Segment.java
@@ -2,14 +2,26 @@
 
 package fugue.schema;
 
-import java.nio.*;
-import java.lang.*;
-import java.util.*;
-import com.google.flatbuffers.*;
+import com.google.flatbuffers.BaseVector;
+import com.google.flatbuffers.BooleanVector;
+import com.google.flatbuffers.ByteVector;
+import com.google.flatbuffers.Constants;
+import com.google.flatbuffers.DoubleVector;
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.google.flatbuffers.FloatVector;
+import com.google.flatbuffers.IntVector;
+import com.google.flatbuffers.LongVector;
+import com.google.flatbuffers.ShortVector;
+import com.google.flatbuffers.StringVector;
+import com.google.flatbuffers.Struct;
+import com.google.flatbuffers.Table;
+import com.google.flatbuffers.UnionVector;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 @SuppressWarnings("unused")
 public final class Segment extends Table {
-  public static void ValidateVersion() { Constants.FLATBUFFERS_2_0_0(); }
+  public static void ValidateVersion() { Constants.FLATBUFFERS_23_3_3(); }
   public static Segment getRootAsSegment(ByteBuffer _bb) { return getRootAsSegment(_bb, new Segment()); }
   public static Segment getRootAsSegment(ByteBuffer _bb, Segment obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
@@ -47,7 +59,7 @@ public final class Segment extends Table {
       int nameOffset,
       long address,
       long size,
-      long address_size,
+      long addressSize,
       long alignment,
       long bits,
       boolean endian,
@@ -65,7 +77,7 @@ public final class Segment extends Table {
     Segment.addBytes(builder, bytesOffset);
     Segment.addBits(builder, bits);
     Segment.addAlignment(builder, alignment);
-    Segment.addAddressSize(builder, address_size);
+    Segment.addAddressSize(builder, addressSize);
     Segment.addSize(builder, size);
     Segment.addName(builder, nameOffset);
     Segment.addExecutable(builder, executable);
@@ -81,10 +93,10 @@ public final class Segment extends Table {
   public static void startSegment(FlatBufferBuilder builder) { builder.startTable(15); }
   public static void addName(FlatBufferBuilder builder, int nameOffset) { builder.addOffset(0, nameOffset, 0); }
   public static void addAddress(FlatBufferBuilder builder, long address) { builder.addLong(1, address, 0L); }
-  public static void addSize(FlatBufferBuilder builder, long size) { builder.addInt(2, (int)size, (int)0L); }
-  public static void addAddressSize(FlatBufferBuilder builder, long addressSize) { builder.addInt(3, (int)addressSize, (int)0L); }
-  public static void addAlignment(FlatBufferBuilder builder, long alignment) { builder.addInt(4, (int)alignment, (int)0L); }
-  public static void addBits(FlatBufferBuilder builder, long bits) { builder.addInt(5, (int)bits, (int)0L); }
+  public static void addSize(FlatBufferBuilder builder, long size) { builder.addInt(2, (int) size, (int) 0L); }
+  public static void addAddressSize(FlatBufferBuilder builder, long addressSize) { builder.addInt(3, (int) addressSize, (int) 0L); }
+  public static void addAlignment(FlatBufferBuilder builder, long alignment) { builder.addInt(4, (int) alignment, (int) 0L); }
+  public static void addBits(FlatBufferBuilder builder, long bits) { builder.addInt(5, (int) bits, (int) 0L); }
   public static void addEndian(FlatBufferBuilder builder, boolean endian) { builder.addBoolean(6, endian, false); }
   public static void addCode(FlatBufferBuilder builder, boolean code) { builder.addBoolean(7, code, false); }
   public static void addData(FlatBufferBuilder builder, boolean data) { builder.addBoolean(8, data, false); }


### PR DESCRIPTION
Version of `flatbuffers-java` specified in `build.gradle` should be equal to version of `flatc` used to generate java code.
I pointed this out in the readme and updated the generated java code and `flatbuffers-java` to `v23.3.3`.